### PR TITLE
Capture keyboard events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.Trashes
+xcuserdata

--- a/CocoaActivityCounter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CocoaActivityCounter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:CocoaActivityCounter.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/CocoaActivityCounter/DBAppDelegate.m
+++ b/CocoaActivityCounter/DBAppDelegate.m
@@ -37,7 +37,7 @@
     return YES;
 }
 
--(void)logMessageToLogView:(NSString*)message {
+- (void)logMessageToLogView:(NSString*)message {
     [logView setString: [[logView string] stringByAppendingFormat:@"%@: %@\n", [self.logDateFormatter stringFromDate:[NSDate date]],  message]];
 }
 
@@ -56,6 +56,15 @@
     if (self.loggingEnabled) {
         return;
     }
+	
+	
+	if (checkAccessibility()) {
+		[self logMessageToLogView:@"Accessibility Enabled"];
+	}
+	else {
+		[self logMessageToLogView:@"Accessibility Disabled"];
+	}
+	
     self.loggingEnabled = true;
     monitorLeftMouseDown = [NSEvent addGlobalMonitorForEventsMatchingMask:NSLeftMouseDownMask handler:^(NSEvent *evt) {
         [self logMessageToLogView:[NSString stringWithFormat:@"Left mouse down!"]];
@@ -89,6 +98,13 @@
         return !self.loggingEnabled;
     }
     return YES;
+}
+
+
+BOOL checkAccessibility()
+{
+	NSDictionary* opts = @{(__bridge id)kAXTrustedCheckOptionPrompt: @YES};
+	return AXIsProcessTrustedWithOptions((__bridge CFDictionaryRef)opts);
 }
 
 @end


### PR DESCRIPTION
I modified your code so that keypress events can be caught again. The app will display a popup when you start logging for the first time, so you can enable accessibility in the system preferences for the app, or if it's run from xcode, you'll have to give permission to xcode.
